### PR TITLE
Fix .env syntax

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 MAPQUEST_API=xxxx
 MYSQL_INIT_FILE=init.sql
-VOLUMEPATH=/data/docker/jsudd
+VOLUME_PATH=/data/docker/jsudd
 MYSQL_ROOT_PASSWORD=xxxx
 MYSQL_USER=xxxx
 MYSQL_PASSWORD=xxxx


### PR DESCRIPTION
The VOLUME_PATH variable was not propely set and was causing a WARNING on
docker-compose up