### PR TITLE
init: travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# @see https://docs.travis-ci.com/user/docker/
+language: php
+
+services:
+  - docker
+
+script:
+  - sudo service mysql stop # travis has a mysql server up, must stop it for mariadb port
+  - make ENV=unittest stop clean init-db start unittest

--- a/docker-compose_sample.yml
+++ b/docker-compose_sample.yml
@@ -27,4 +27,3 @@ services:
        - ${VOLUME_PATH}/files/maps:${ROOT_APP_DIR}/maps
        - ${VOLUME_PATH}/files/images:${ROOT_APP_DIR}/images
        - ${VOLUME_PATH}/logs/apache2/var_log_apache2:/var/log/apache2
-

--- a/docker-compose_unittest.yml
+++ b/docker-compose_unittest.yml
@@ -18,7 +18,7 @@ services:
      working_dir: /app
      ports:
        - "80:80"
-     links:
+     depends_on:
        - db
      volumes:
        - ./:${ROOT_APP_DIR}


### PR DESCRIPTION
Utiliser [travis](https://travis-ci.org/) comme système d'intégration continue, pour avoir le status de chaque PR

Exemple de build:
* https://travis-ci.org/polomarcus/vigilo-backend
* Status dans la PR: https://github.com/polomarcus/vigilo-backend/pull/1

Documentation sur le build:
* https://docs.travis-ci.com/user/docker/

Nécessite d'activiter en quelques minutes travis sur le repo

## Docker compose file
Utilise `depends_on` plutôt que `links` [deprecated](https://docs.docker.com/compose/compose-file/#links) 