### PR TITLE
mysql: 0.0.10 - Fix obs_status_resolved

### DIFF
--- a/mysql/init/init-0.0.10.sql
+++ b/mysql/init/init-0.0.10.sql
@@ -2,5 +2,7 @@ ALTER TABLE `obs_roles` ADD UNIQUE(`role_login`);
 ALTER TABLE `obs_list` ADD `obs_status_resolved_time` BIGINT NOT NULL AFTER `obs_status`, ADD `obs_status_resolved_comment` VARCHAR(255) NOT NULL AFTER `obs_status_resolved_time`, ADD `obs_status_resolved_hasphoto` BOOLEAN NOT NULL AFTER `obs_status_resolved_comment`;
 ALTER TABLE `obs_list` CHANGE `obs_status_resolved_hasphoto` `obs_status_resolved_hasphoto` TINYINT(1) NOT NULL DEFAULT '0';
 
+ALTER TABLE `obs_list` CHANGE `obs_status_resolved_time` `obs_status_resolved_time` BIGINT(20) NULL DEFAULT NULL;
+ALTER TABLE `obs_list` CHANGE `obs_status_resolved_comment` `obs_status_resolved_comment` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NULL DEFAULT NULL;
 UPDATE `obs_config` SET `config_value` = '0.0.10' WHERE `obs_config`.`config_param` = 'vigilo_db_version';
 


### PR DESCRIPTION
Add missing default values. Backend was unable to insert data in obs_list table without default values.