### PR TITLE
create_issue: introduce obs_city field in observations

### DIFF
--- a/app/create_issue.php
+++ b/app/create_issue.php
@@ -26,8 +26,6 @@ header('BACKEND_VERSION: '.BACKEND_VERSION);
 header('Content-Type: application/json; charset=utf-8');
 header('Access-Control-Allow-Origin: *');
 
-# Generate Unique ID
-$secretid=str_replace('.', '', uniqid('', true));
 
 if (isset($_GET['key'])) {
   $key = $_GET['key'];
@@ -36,129 +34,240 @@ else {
   $key = Null;
 }
 
-# Get Web form datas
+# First we need to know if it's an new issue or an update from an admin
+
+$update = 0;
+
+# Check if token exists
+if (isset($_POST['token']) AND !empty($_POST['token'])) {
+  $token = mysqli_real_escape_string($db, $_POST['token']);
+  if (getrole($key, $acls) == "admin") {
+    # Do the query only if it's an admin
+    $query_token = mysqli_query($db, "SELECT * FROM obs_list WHERE obs_token='".$token."' LIMIT 1");
+    # If token exists and the request is from an admin : We consider it as an update
+    if (mysqli_num_rows($query_token) == 1) {
+      delete_map_cache($token);
+      delete_token_cache($token);
+      $result_token = mysqli_fetch_array($query_token);
+      $secretid = $result_token['obs_secretid'];
+      $update = 1;
+    }
+  }
+}
+
+# In all other cases generate secret and token
+if (!$update) {
+  # Generate a unique ID
+  $secretid = str_replace('.', '', uniqid('', true));
+
+  # Generate a unique token
+  $token = tokenGenerator(4);
+}
+
+$json = array('token' => $token, 'status' => 0, 'secretid' => $secretid);
+
+# Handle mandatory fields
+# Even if an admin is updating the observation, is has to send again all
+# information anyway. Then, send an error if parameters are missing too.
+if (!isset($_POST['coordinates_lat']) ||
+    !isset($_POST['coordinates_lon']) ||
+    !isset($_POST['categorie']) ||
+    !isset($_POST['address']) ||
+    !isset($_POST['time']) ||
+    !isset($_POST['scope'])) {
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Missing parameters";
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
 
 $coordinates_lat = mysqli_real_escape_string($db, $_POST['coordinates_lat']);
 $coordinates_lon = mysqli_real_escape_string($db, $_POST['coordinates_lon']);
-
-/* Handle comment content */
-$comment = removeEmoji(mysqli_real_escape_string($db, $_POST['comment']));
-$comment = substr($comment,0,50);
-
 $categorie = mysqli_real_escape_string($db, $_POST['categorie']);
 $address = mysqli_real_escape_string($db, $_POST['address']);
+$scope = (isset($_POST['scope']) ? mysqli_real_escape_string($db, $_POST['scope']) : 0);
 $time = mysqli_real_escape_string($db, $_POST['time']);
 
+if (empty($coordinates_lat) or empty($coordinates_lon) or
+    empty($categorie) or empty($time) or empty($address)) {
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Empty field not supported";
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
+
+# TODO : test time if value is too high or too low
+
 /* If time is sent in ms */
-if(strlen($time) == 14) {
+if (strlen($time) == 14) {
   $time = floor($time / 1000);
 }
 
-$explanation = (isset($_POST['explanation']) ? removeEmoji(mysqli_real_escape_string($db, $_POST['explanation'])) : '');
-$version = (isset($_POST['version']) ? mysqli_real_escape_string($db, $_POST['version']) : 0);
-$scope = (isset($_POST['scope']) ? mysqli_real_escape_string($db, $_POST['scope']) : 0);
-$status = 0;
+# Handle optional fields
+if (isset($_POST['comment'])) {
+  $comment = removeEmoji(mysqli_real_escape_string($db, $_POST['comment']));
+  $comment = substr($comment, 0, 50); # Max 50 char
+} else {
+  $comment = Null;
+}
+
+if (isset($_POST['explanation'])) {
+  $explanation = (isset($_POST['explanation']) ? removeEmoji(mysqli_real_escape_string($db, $_POST['explanation'])) : '');
+} else {
+  $explanation = Null;
+}
+
+if (isset($_POST['version'])) {
+  $version = (isset($_POST['version']) ? mysqli_real_escape_string($db, $_POST['version']) : 0);
+} else {
+  $version = Null;
+}
 
 # Check scope compliancy
+
 $query_scope = mysqli_query($db, "SELECT * FROM obs_scopes WHERE scope_name='".$scope."' LIMIT 1");
 $result_scope = mysqli_fetch_array($query_scope);
-if($coordinates_lat >= $result_scope['scope_coordinate_lat_min'] &&
-   $coordinates_lat <= $result_scope['scope_coordinate_lat_max'] &&
-   $coordinates_lon >= $result_scope['scope_coordinate_lon_min'] &&
-   $coordinates_lon <= $result_scope['scope_coordinate_lon_max']) {
-  
-  # Check if token exist
-  #
-  if(isset($_POST['token']) AND !empty($_POST['token'])) {
-    $token = mysqli_real_escape_string($db, $_POST['token']);
-  }
-  else {
-    $token = tokenGenerator(4);
-  }
-
-  $query_token = mysqli_query($db, "SELECT * FROM obs_list WHERE obs_token='".$token."' LIMIT 1");
-
-  /* If token exists and the request is from an admin : We consider it as an update */
-  if (mysqli_num_rows($query_token) == 1 && getrole($key, $acls) == "admin") {
-    delete_map_cache($token);
-    delete_token_cache($token);
-    $result_token = mysqli_fetch_array($query_token);
-    $secretid = $result_token['obs_secretid'];
-    $json = array('token' => $token, 'status' => 0, 'secretid'=>$secretid);
-    mysqli_query($db,'UPDATE obs_list SET obs_coordinates_lat="'.$coordinates_lat.'",
-                                          obs_coordinates_lon="'.$coordinates_lon.'",
-                                          obs_comment="'.$comment.'",
-                                          obs_explanation="'.$explanation.'",
-                                          obs_address_string="'.$address.'",
-                                          obs_categorie="'.$categorie.'",
-                                          obs_time="'.$time.'",
-                                          obs_app_version="'.$version.'"
-                      WHERE obs_token="'.$token.'" AND obs_secretid="'.$secretid.'"');
-  }
-  else {
-  
-    if (mysqli_num_rows($query_token) == 1 or empty($token)) {
-      $token = tokenGenerator(4);
-    }
-  
-    # Init Datas
-    $json = array('token' => $token, 'status' => 0, 'secretid' => $secretid);
-  
-    # Insert user datas to MySQL Database
-    if (!empty($coordinates_lat) and !empty($coordinates_lon) and !empty($categorie) and !empty($time) and !empty($address)) {
-      mysqli_query($db, 'INSERT INTO obs_list (
-                                      `obs_scope`,
-                                      `obs_coordinates_lat`,
-                                      `obs_coordinates_lon`,
-                                      `obs_address_string`,
-                                      `obs_comment`,
-                                      `obs_explanation`,
-                                      `obs_categorie`,
-                                      `obs_token`,
-                                      `obs_time`,
-                                      `obs_status`,
-                                      `obs_app_version`,
-                                      `obs_secretid`) 
-                               VALUES (
-                                   "'.$scope.'",
-                                   "'.$coordinates_lat.'",
-                                   "'.$coordinates_lon.'",
-                                   "'.$address.'",
-                                   "'.$comment.'",
-                                   "'.$explanation.'",
-                                   "'.$categorie.'",
-                                   "'.$token.'",
-                                   "'.$time.'",
-                                   0,
-                                   "'.$version.'",
-                                   "'.$secretid.'")');
-          
-      if ($mysqlerror = mysqli_error($db)) {
-        $status = 1;
-        $error_code = "Could not insert field";
-        error_log('CREATE_ISSUE : MySQL Error '.$mysqlerror);
-      }
-    }
-    else {
-      $status = 1;
-      $error_code = "Empty field not supported";
-      error_log('CREATE_ISSUE : Field not supported');
-    }
-  }  
-}
-else {
-  $status = 1;
-  $error_code = "Coordinates out of range in the scope";
-  error_log('CREATE ISSUE' . $error_code);
-}
-# If error force return 500 ERROR CODE
-if ($status != 0) {
-  http_response_code(500);
+if (!$result_scope) {
+  # No result found for this scope
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Unknown scope";
+  $json['status'] = 1;
+  $json['group'] = 0;
   $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
+
+# Check if observation is located inside rectangle area of the scope
+if (!($coordinates_lat >= $result_scope['scope_coordinate_lat_min'] &&
+      $coordinates_lat <= $result_scope['scope_coordinate_lat_max'] &&
+      $coordinates_lon >= $result_scope['scope_coordinate_lon_min'] &&
+      $coordinates_lon <= $result_scope['scope_coordinate_lon_max'])) {
+  # We are outside the area
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Coordinates out of range and not located in the scope '$scope'";
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
+
+# Get list of cities within the scope
+$query_cities = mysqli_query($db, "SELECT * FROM obs_cities WHERE city_scope='".$result_scope['scope_id']."'");
+if (mysqli_num_rows($query_cities) == 0) {
+  # No city found, that's a problem
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "No city found within the scope ".$result_scope['scope_id'];
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
+
+# Check if observation is located in a city listed within the scope
+$nominatim_json = get_data_from_gps_coordinates($coordinates_lat, $coordinates_lon);
+$obs_address = $nominatim_json['address'];
+$postcode = $obs_address['postcode'];
+$town = $obs_address['town'];
+$road = $obs_address['road'];
+
+$city_found = 0;
+$city_id = 0;
+while($city = mysqli_fetch_array($query_cities)) {
+  $post_code = $city['city_postcode'];
+  if ($city['city_postcode'] == $postcode) {
+    $city_found = 1;
+    $city_id = $city['city_id'];
+    break;
+  }
+}
+
+if (!$city_found) {
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Coordinates are not located in the scope '$scope' - '$postcode : $town' is not supported";
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE' . $error_code);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
+}
+
+if ($update) {
+  mysqli_query($db, 'UPDATE obs_list SET obs_coordinates_lat="'.$coordinates_lat.'",
+                                         obs_coordinates_lon="'.$coordinates_lon.'",
+                                         obs_city="'.$city_id.'",
+                                         obs_comment="'.$comment.'",
+                                         obs_explanation="'.$explanation.'",
+                                         obs_address_string="'.$address.'",
+                                         obs_categorie="'.$categorie.'",
+                                         obs_time="'.$time.'",
+                                         obs_app_version="'.$version.'"
+                    WHERE obs_token="'.$token.'" AND obs_secretid="'.$secretid.'"');
+} else {
+  mysqli_query($db, 'INSERT INTO obs_list (
+                                  `obs_scope`,
+                                  `obs_city`,
+                                  `obs_coordinates_lat`,
+                                  `obs_coordinates_lon`,
+                                  `obs_address_string`,
+                                  `obs_comment`,
+                                  `obs_explanation`,
+                                  `obs_categorie`,
+                                  `obs_token`,
+                                  `obs_time`,
+                                  `obs_status`,
+                                  `obs_app_version`,
+                                  `obs_secretid`)
+                           VALUES (
+                               "'.$scope.'",
+                               "'.$city_id.'",
+                               "'.$coordinates_lat.'",
+                               "'.$coordinates_lon.'",
+                               "'.$address.'",
+                               "'.$comment.'",
+                               "'.$explanation.'",
+                               "'.$categorie.'",
+                               "'.$token.'",
+                               "'.$time.'",
+                               0,
+                               "'.$version.'",
+                               "'.$secretid.'")');
+}
+
+if ($mysqlerror = mysqli_error($db)) {
+  # TODO : use jsonError and find a better and generic error code handling
+  $error_code = "Could not insert field";
+  $json['status'] = 1;
+  $json['group'] = 0;
+  $json['error_code'] = $error_code;
+  error_log('CREATE ISSUE : MySQL Error '.$mysqlerror);
+  http_response_code(500);
+  echo json_encode($json, JSON_PRETTY_PRINT);
+  return;
 }
 
 # Return Token value
-$json['status'] = $status;
+$json['status'] = 1;
 $json['group'] = 0;
 echo json_encode($json);
 ?>

--- a/app/includes/functions.php
+++ b/app/includes/functions.php
@@ -44,6 +44,23 @@ function distance($lat1, $lng1, $lat2, $lng2, $unit = 'k') {
         return $meter;
 }
 
+function get_data_from_gps_coordinates($lat, $lon)
+{
+  $options = array(
+    'http'=>array(
+      'method'=>"GET",
+      'header'=>"User-Agent: Vigilo Backend Version/".BACKEND_VERSION." \r\n"
+    )
+  );
+  // MAX 1 request per second
+  // https://operations.osmfoundation.org/policies/nominatim/
+  $url='https://nominatim.openstreetmap.org/reverse?format=json&lat='.$lat.'&lon='.$lon;
+  $context = stream_context_create($options);
+  $resp_json = file_get_contents($url, false, $context);
+  $resp = json_decode($resp_json, true);
+  return $resp;
+}
+
 function delete_token_cache($token) {
     foreach(glob(__DIR__."/../caches/".$token."*") as $file) {
         unlink($file);

--- a/doc/REST_API.md
+++ b/doc/REST_API.md
@@ -326,15 +326,15 @@ Version backend >= 0.0.1
 | ------------ | ---- | ----|------------ | ------------- | --------------|
 | URL | str | key | | Clé privé de l'utilisateur | >= 0.0.1 |
 | Form | str | token | Uniquement en cas de modif | Token de l'observation | >= 0.0.1 |
-| Form | str | coordinates_lat' | X | Latitude de l'observation | >= 0.0.1 |
-| Form | str | coordinates_lon | X | Longitude de l'observation | >= 0.0.1 |
-| Form | str | comment | X | Remarque de l'observation (max 50 caractères) | >= 0.0.1 |
-| Form | str | explanation | X | Explications observation | >= 0.0.1 |
-| Form | str | categorie | X | ID de catégorie | >= 0.0.1 |
-| Form | str | address | X | Adresse de l'observation | >= 0.0.1 |
-| Form | str | time | X |  Timestamp de l'observation au format Unix en ms | >= 0.0.1 |
-| Form | str | version | X | Version de l'application cliente | >= 0.0.1 |
-| Form | str | scope | X | Identifiant du scope | >= 0.0.1 |
+| Form | str | coordinates_lat' | création | Latitude de l'observation | >= 0.0.1 |
+| Form | str | coordinates_lon | création | Longitude de l'observation | >= 0.0.1 |
+| Form | str | comment | non | Remarque de l'observation (max 50 caractères) | >= 0.0.1 |
+| Form | str | explanation | non | Explications observation | >= 0.0.1 |
+| Form | str | categorie | création | ID de catégorie | >= 0.0.1 |
+| Form | str | address | création | Adresse de l'observation | >= 0.0.1 |
+| Form | str | time | création |  Timestamp de l'observation au format Unix en ms | >= 0.0.1 |
+| Form | str | version | création | Version de l'application cliente | >= 0.0.1 |
+| Form | str | scope | création | Identifiant du scope | >= 0.0.1 |
 
 ###### Retour
 

--- a/mysql/init/init-0.0.10.sql
+++ b/mysql/init/init-0.0.10.sql
@@ -1,6 +1,7 @@
 ALTER TABLE `obs_roles` ADD UNIQUE(`role_login`); 
 ALTER TABLE `obs_list` ADD `obs_status_resolved_time` BIGINT NOT NULL AFTER `obs_status`, ADD `obs_status_resolved_comment` VARCHAR(255) NOT NULL AFTER `obs_status_resolved_time`, ADD `obs_status_resolved_hasphoto` BOOLEAN NOT NULL AFTER `obs_status_resolved_comment`;
 ALTER TABLE `obs_list` CHANGE `obs_status_resolved_hasphoto` `obs_status_resolved_hasphoto` TINYINT(1) NOT NULL DEFAULT '0';
+ALTER TABLE `obs_list` ADD `obs_city` SMALLINT(4) NOT NULL AFTER `obs_scope`;
 
 UPDATE `obs_config` SET `config_value` = '0.0.10' WHERE `obs_config`.`config_param` = 'vigilo_db_version';
 


### PR DESCRIPTION
This patch now uses city information described in database from the
configured scope.

Each observation

- is now tested with a Nominatim API call to verify the observation is
  within limits of the scope.

- has now an obs_city field (based on GPS coordinates) so we can easily
  filter observations by city.

It is important to know Nominatim API calls are limited to 1 per second.
For now it should work, but we should find a better solution for the
long term.

With this patch

- all new observations are properly located within the scope and we
  can't accept observations outside of it. This should ease moderation
  from now.

- all new obserations will have the obs_city field. Older ones won't
  have it for now. We should plan a migration when we will want to use
  that field later on.

- several fields used by create_issue.php are now mandatory. It used to
  make no sense to create issues without gps coordinates, time,
  categorie, scope and address. Documentation has been changed
  accordingly.