### PR TITLE
mysql: add primary keys for edition

### DIFF
--- a/mysql/init/init-0.0.11.sql
+++ b/mysql/init/init-0.0.11.sql
@@ -1,2 +1,4 @@
-UPDATE `obs_config` SET `config_value` = '0.0.11' WHERE `obs_config`.`config_param` = 'vigilo_db_version';
+ALTER TABLE `obs_twitteraccounts` ADD PRIMARY KEY(`ta_id`);
+ALTER TABLE `obs_cities` ADD PRIMARY KEY(`city_id`);
 
+UPDATE `obs_config` SET `config_value` = '0.0.11' WHERE `obs_config`.`config_param` = 'vigilo_db_version';


### PR DESCRIPTION
- obs_twitteraccounts
- obs_cities

without unique column (primary key) we can't select, edit, copy, delete
data from phpmyadmin.