### PR TITLE
Security fix

### DIFF
--- a/app/admin/inc/accounts.php
+++ b/app/admin/inc/accounts.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/inc/accounts.php
+++ b/app/admin/inc/accounts.php
@@ -21,6 +21,10 @@ if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role
     exit('Not allowed');
 }
 
+if (isset($_GET['ask_pwd_update'])) {
+    echo '<div class="alert alert-danger" role="alert">Pour des raisons de sécurité, merci de mettre à jour le mot de passe de votre compte</div>';
+}
+
 if (isset($_GET['action']) && !isset($_POST['role_id'])) {
     if ($_GET['action'] == 'add') {
         mysqli_query($db, "INSERT INTO obs_roles (role_key,
@@ -52,7 +56,7 @@ if (isset($_POST['role_id'])) {
             $value = mysqli_real_escape_string($db, $value);
             if ($key == 'role_password') {
                 if ($value != '') {
-                    $value = hash('sha256', $value);
+                    $value = password_hash($value, PASSWORD_DEFAULT);
                 }
             }
             if (!($key == 'role_password' && $value == '')) {

--- a/app/admin/inc/cities.php
+++ b/app/admin/inc/cities.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/inc/observations.php
+++ b/app/admin/inc/observations.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'],$menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
   exit('Not allowed');
 }
 

--- a/app/admin/inc/scopes.php
+++ b/app/admin/inc/scopes.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/inc/settings.php
+++ b/app/admin/inc/settings.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/inc/twitter.php
+++ b/app/admin/inc/twitter.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/inc/update.php
+++ b/app/admin/inc/update.php
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-if (!isset($page_name) || (isset($_SESSION['role']) && !in_array($_SESSION['role'], $menu[$page_name]['access']))) {
+if (!isset($page_name) || !isset($_SESSION['role']) || !in_array($_SESSION['role'], $menu[$page_name]['access'])) {
     exit('Not allowed');
 }
 

--- a/app/admin/index.php
+++ b/app/admin/index.php
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 session_start();
 
-if(!isset($_SESSION['login'])) {
+if(!isset($_SESSION['login']) || !isset($_SESSION['role'])) {
   header('Location: login.php');
 }
 

--- a/app/admin/login.php
+++ b/app/admin/login.php
@@ -28,13 +28,8 @@ if (isset($_POST['login'])) {
   if (hash('sha256',$_POST['password']) == $login_result['role_password']) {
     $_SESSION['login'] = $login;
     $_SESSION['role'] = $login_result['role_name'];
-    if (isset($_POST['rememberme'])) {
-      setcookie("admin-key",$login_result['role_key'],time()+2678400);
-    }
+
     header('Location: index.php');
-  }
-  elseif (isset($_COOKIE['admin-key']) && $_COOKIE['admin-key'] == $login_result['role_key']) {
-    $_SESSION['login'] = $login;
   }
   else {
     $badlogin = True;
@@ -130,11 +125,6 @@ else {
       <input type="text" name='login' class="form-control" placeholder="Login" required autofocus>
       <label for="inputPassword" class="sr-only">Password</label>
       <input type="password" name='password' class="form-control" placeholder="Password" required>
-      <div class="checkbox mb-3">
-        <label>
-          <input type="checkbox" name="rememberme" value="remember-me"> Remember me
-        </label>
-      </div>
       <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
       <p class="mt-5 mb-3 text-muted">&copy; 2017-2018</p>
     </form>

--- a/app/admin/login.php
+++ b/app/admin/login.php
@@ -25,13 +25,20 @@ if (isset($_POST['login'])) {
   $login = mysqli_real_escape_string($db,$_POST['login']);
   $login_query = mysqli_query($db,"SELECT * FROM obs_roles WHERE role_login = '".$login."' AND role_name='admin' OR role_name='citystaff' LIMIT 1");
   $login_result = mysqli_fetch_array($login_query);
-  if (hash('sha256',$_POST['password']) == $login_result['role_password']) {
+
+  if (password_verify($_POST['password'], $login_result['role_password'])) {
     $_SESSION['login'] = $login;
     $_SESSION['role'] = $login_result['role_name'];
 
     header('Location: index.php');
-  }
-  else {
+  } elseif (hash('sha256',$_POST['password']) == $login_result['role_password']) {
+    $newHash = password_hash($_POST['password'], PASSWORD_DEFAULT);
+
+    $_SESSION['login'] = $login;
+    $_SESSION['role'] = $login_result['role_name'];
+
+    header('Location: index.php?page=accounts&ask_pwd_update=1');
+  } else {
     $badlogin = True;
   }
 }

--- a/app/get_issues.php
+++ b/app/get_issues.php
@@ -83,7 +83,7 @@ class GetIssues
 
   public function setCategorie($value) : void
   {
-    $this->categorie = explode(',',$value);
+    $this->categorie = explode(',', mysqli_real_escape_string($this->db, $value));
   }
 
   public function setStatus($value) : void
@@ -106,7 +106,7 @@ class GetIssues
 
   public function setToken($value) : void
   {
-    $this->token = $value;
+    $this->token = mysqli_real_escape_string($this->db, $value);
   }
 
   public function setTokenFilers($filters,$fdistance=-1) {

--- a/install_app/install.php
+++ b/install_app/install.php
@@ -13,7 +13,7 @@ if(isset($_POST['password']) && !empty($_POST['password'])) {
    $diffpass = TRUE;
  }
  else {
-   $password=hash('sha256',$_POST['password']);
+   $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
 
    mysqli_query($db,"INSERT INTO obs_roles (role_key,
                                             role_name,

--- a/install_app/install.php
+++ b/install_app/install.php
@@ -14,16 +14,14 @@ if(isset($_POST['password']) && !empty($_POST['password'])) {
  }
  else {
    $password=hash('sha256',$_POST['password']);
-   if(empty($_POST['key'])) {
-     $key = str_replace('.', '', uniqid('', true));
-   }
+
    mysqli_query($db,"INSERT INTO obs_roles (role_key,
                                             role_name,
                                             role_owner,
                                             role_login,
                                             role_password,
                                             role_city)
-                             VALUES ('',
+                             VALUES ('".strtoupper(bin2hex(random_bytes(20)))."',
                                       'admin',
                                       '".$_POST['name']."',
                                       '".$_POST['login']."',


### PR DESCRIPTION
# Description
- Ajout de protection contre les injections SQL pour deux champs dans `get_issues.php`
- La vérification des autorisations dans la partie admin ne gérait pas correctement l'absence de rôle en session, en utilisant cette faille avec la fonction "Remember me" il est possible de se connecter à l'admin sans compte 
- Lors de l'installation initialise le compte par défaut `admin` avec un `role_key` aléatoire plutôt que vide, il n'y a pas de faille détectée là-dessus mais ça me semble dangereux
- Suppression de la fonctionnalité "Remember me" pour se connecter à l'admin : elle introduit une faiblesse au niveau sécurité, de plus son utilisation normale me semble cassée ou il y a quelque chose que je n'ai pas compris dans son utilisation
- Renforcement de la sécurité des mots de passe stockés en base de données (répond à l'issue https://github.com/jesuisundesdeux/vigilo-backend/issues/229), la transition entre les 2 formats de mot de passe se fait à la première connexion de l'utilisateur

### If necessary, please
* Update **documentation** or README
* write unit or/and functional **tests**
* [squash your commit manually](https://stackoverflow.com/a/5189600/3535853) or ["squash and merge" on github](https://help.github.com/en/articles/merging-a-pull-request)
