### PR TITLE
Add a filter on relative dates

### DIFF
--- a/doc/REST_API.md
+++ b/doc/REST_API.md
@@ -218,6 +218,8 @@ Version backend >= 0.0.1
 | URL | bool | cityfield | | Affiche la ville dans un champs dédié plutôt que dans l'adresse | >= 0.0.13 |
 | URL | int | cityid | | filtre selon id de la ville | >= 0.0.13 |
 | URL | str | key | | Clé d'admin pour donner accès à toutes les observations | >= 0.0.13 |
+| URL | int | since | | nombre d'unités pour le filtre relatif sur la date | >= 0.0.19 |
+| URL | str | since_unit | | unité pour le filtre relatif sur la date, valeur parmi : day, week, month, year  | >= 0.0.19 |
 
 
 ###### Retour


### PR DESCRIPTION
# Description
- Ajout de deux paramètres à `get_issues.php` pour filtrer les observations avec une date relative à l'instant présent.

Le besoin est notamment pour pouvoir créer des cartes avec umap affichant les observations pour une période donnée. Actuellement on peut établir une carte pour les observations depuis le 1er janvier par-exemple mais pas pour les 15 derniers jours.
Ce filtre pourrait aussi être utilisé par la web app si celle-ci évolue pour ne pas requêter en une seule fois toutes les observations.

### If necessary, please
* Update **documentation** or README
* write unit or/and functional **tests**
* [squash your commit manually](https://stackoverflow.com/a/5189600/3535853) or ["squash and merge" on github](https://help.github.com/en/articles/merging-a-pull-request)
