### PR TITLE
Fix d'un bug dans le login d'un citystaff. 

### DIFF
--- a/app/admin/login.php
+++ b/app/admin/login.php
@@ -23,7 +23,7 @@ require_once('../includes/common.php');
 $badlogin = False;
 if (isset($_POST['login'])) {
   $login = mysqli_real_escape_string($db,$_POST['login']);
-  $login_query = mysqli_query($db,"SELECT * FROM obs_roles WHERE role_login = '".$login."' AND role_name='admin' OR role_name='citystaff' LIMIT 1");
+  $login_query = mysqli_query($db,"SELECT * FROM obs_roles WHERE role_login = '".$login."' AND (role_name='admin' OR role_name='citystaff') LIMIT 1");
   $login_result = mysqli_fetch_array($login_query);
 
   if (password_verify($_POST['password'], $login_result['role_password'])) {


### PR DESCRIPTION
# Description
1) Fix d'un bug dans le login d'un citystaff. 

- Lors de la création d'un second citystaff, celui-ci ne peux se logger
- C'est du a la condition de requete de login qui combine les opérateur AND et OR sans parenthèse de la mauvaise manière (AND est prioritaire sur OR)
- Actuellement (on cherche le login correspondant qui est de role "admin") OU on va prendre le premier citystaff qui vient


### If necessary, please
* Update **documentation** or README
* write unit or/and functional **tests**
* [squash your commit manually](https://stackoverflow.com/a/5189600/3535853) or ["squash and merge" on github](https://help.github.com/en/articles/merging-a-pull-request)
