### PR TITLE
fix: default panel mapquest image path

### DIFF
--- a/app/generate_panel.php
+++ b/app/generate_panel.php
@@ -134,7 +134,7 @@ $map_file_path = $maps_path . $token . '_zoom.jpg';
 $res = GenerateMapQuestForToken($token, $map_file_path, $config['MAPQUEST_API']);
 if (!$res) {
     // Use default place holder picture instead of crashing
-    $map_file_path = "$cwd/panel_components/map_error.jpeg";
+    $map_file_path = implode(DIRECTORY_SEPARATOR, [$cwd, 'panels', $panel_path, 'panel_components', 'map_error.jpeg']);
 }
 
 $map = imagecreatefromjpeg($map_file_path);


### PR DESCRIPTION
- fix default panel mapquest image path, change appears since version 0.0.16

From Marseille, we did an update from a fresh data installation and this path was missing. We discovered it because at the same time, our Mapquest key is outdated, so we fell into this default behavior.